### PR TITLE
Added hook for specifying HttpHeaders

### DIFF
--- a/packages/ember-droplet/ember-droplet-mixin.js
+++ b/packages/ember-droplet/ember-droplet-mixin.js
@@ -13,6 +13,14 @@ window.DropletController = Ember.Mixin.create({
     mimeTypes: ['image/jpeg', 'image/jpg', 'image/gif', 'image/png', 'text/plain'],
 
     /**
+     * @property requestHeaders
+     * @type {Object}
+     * Contains a list of headers to be included in the request made by
+     * uploadAllFiles()
+     */
+    requestHeaders: {},
+
+    /**
      * @property files
      * @type {Array}
      * @default []
@@ -119,6 +127,12 @@ window.DropletController = Ember.Mixin.create({
 
             // Set the request size, and then we can upload the files!
             request.setRequestHeader('X-File-Size', this._getSize());
+
+            for (var key in this.get('requestHeaders')) {
+                request.setRequestHeader(
+                    key, this.get('requestHeaders')[key]);
+            }
+
             request.send(formData);
 
             // Return the promise.


### PR DESCRIPTION
Needed to be able to specify a CSRF token in my app when using EmberDroplet so I came up with this code. Please let me know your thoughts.  Now I can do the following:

``` javascript
App.FilesUploadController = Ember.Controller.extend(DropletController, {

     requestHeaders: {
        'X-CSRFToken': ENV.CSRF_TOKEN
     }

});
```
