### PR TITLE
The status and version badges should link to Travis-ci and NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ember Droplet
 
 [![Build Status](https://travis-ci.org/Wildhoney/EmberDroplet.svg?branch=master)](https://travis-ci.org/Wildhoney/EmberDroplet)
 &nbsp;
-<img src="https://badge.fury.io/js/ember-droplet.png" />
+[![NPM version](https://badge.fury.io/js/ember-droplet.svg)](http://badge.fury.io/js/ember-droplet)
 
 **Demo**: http://droplet.wildhoney.io/
 


### PR DESCRIPTION
**As a** developer 
**In order to** ensure the status badge reflects the latest build status 
**And** to be able to see the test suite at Travis-ci 
**And** to be able to get more details about the package from the NPM home 
**I want** the status and version badges to be included in the `README` in the standard way 

Hello @Wildhoney,

This is a very minor improvement, but I think the _EmberDroplet_ test suite is worth to be made visible ; )
