### PR TITLE
Create an upload status per instance

### DIFF
--- a/packages/ember-droplet/ember-droplet-mixin.js
+++ b/packages/ember-droplet/ember-droplet-mixin.js
@@ -53,7 +53,9 @@
          * @property uploadStatus
          * @type {Object}
          */
-        uploadStatus: { uploading: false, percentComplete: 0, error: false },
+        uploadStatus: Ember.computed(function() {
+          return { uploading: false, percentComplete: 0, error: false };
+        }),
 
         /**
          * Clears the file array for each instantiation.

--- a/tests/spec.js
+++ b/tests/spec.js
@@ -59,15 +59,6 @@ describe('Ember Crossfilter', function() {
             expect(Ember.get(controller, 'deletedFiles.length')).toEqual(0);
         });
 
-        it('Can clear all files from the list', function() {
-            controller.send('clearAllFiles');
-            expect(Ember.get(controller, 'files.length')).toEqual(0);
-            expect(Ember.get(controller, 'validFiles.length')).toEqual(0);
-            expect(Ember.get(controller, 'invalidFiles.length')).toEqual(0);
-            expect(Ember.get(controller, 'uploadedFiles.length')).toEqual(0);
-            expect(Ember.get(controller, 'deletedFiles.length')).toEqual(0);
-        });
-
         it('does not attempt to abort when there is no upload', function() {
             var requestSpy = jasmine.createSpyObj('request', ['abort'])
             Ember.set(controller, 'uploadStatus.uploading', false);
@@ -88,6 +79,14 @@ describe('Ember Crossfilter', function() {
             expect(requestSpy.abort).toHaveBeenCalled();
         });
 
+        it('Creates an upload status per instance', function() {
+          otherController = Ember.Controller.createWithMixins(DropletController);
+
+          controller.set("uploadStatus.uploading", true)
+
+          expect(otherController.get("uploadStatus.uploading")).toEqual(false);
+          expect(controller.get("uploadStatus.uploading")).toEqual(true);
+        });
     });
 
     describe('View', function() {


### PR DESCRIPTION
Fixes shared state between multiple controllers that use the DropletController mixin. For instance we've been having to reset state at the end of our unit tests.
