### PR TITLE
Define lastRequest as local variable instead of global

### DIFF
--- a/packages/ember-droplet/ember-droplet-mixin.js
+++ b/packages/ember-droplet/ember-droplet-mixin.js
@@ -242,7 +242,7 @@
         willDestroy: function() {
           this._super.apply(this, arguments);
 
-          lastRequest = this.get("lastRequest")
+          var lastRequest = this.get("lastRequest")
 
           if (lastRequest) {
             delete lastRequest.onreadystatechange;


### PR DESCRIPTION
Fixes an exception that gets raised in newer browsers
