### PR TITLE
Null event handlers instead of deleting

### DIFF
--- a/packages/ember-droplet/ember-droplet-mixin.js
+++ b/packages/ember-droplet/ember-droplet-mixin.js
@@ -245,10 +245,10 @@
           var lastRequest = this.get("lastRequest")
 
           if (lastRequest) {
-            delete lastRequest.onreadystatechange;
-            delete lastRequest.upload.onprogress;
-            delete lastRequest.upload.onload;
-            delete lastRequest.upload.onerror;
+            lastRequest.onreadystatechange = undefined;
+            lastRequest.upload.onprogress = undefined;
+            lastRequest.upload.onload = undefined;
+            lastRequest.upload.onerror = undefined;
             this.send('abortUpload');
           }
         },


### PR DESCRIPTION
Older versions of phantomjs don't allow you to delete event handlers on XMLHttpRequest
