### PR TITLE
Fix issue where hooks are being overwritten by Mixin init

### DIFF
--- a/components/Droplet.js
+++ b/components/Droplet.js
@@ -259,7 +259,6 @@
         init() {
 
             set(this, 'files', []);
-            set(this, 'hooks', {});
 
             Object.keys(DEFAULT_OPTIONS).forEach(key => {
 
@@ -286,7 +285,7 @@
         willDestroy() {
 
             this._super();
-            
+
             const lastRequest = this.get('lastRequest');
 
             if (lastRequest) {
@@ -453,7 +452,7 @@
             });
 
             return formData;
-            
+
         },
 
         /**
@@ -893,7 +892,7 @@
         handleFiles(models) {
             this.DropletEventBus && this.DropletEventBus.publish(EVENT_NAME, ...fromArray(models));
         }
-        
+
     });
 
     /**

--- a/tests/Droplet.test.js
+++ b/tests/Droplet.test.js
@@ -8,6 +8,10 @@ describe('Ember Droplet', () => {
     beforeEach(() => {
 
         const Component = Ember.Component.extend(Droplet, {
+            hooks: {
+              didAdd: () => {},
+              didDelete: () => {}
+            },
             url: exampleUrl
         });
 
@@ -90,9 +94,6 @@ describe('Ember Droplet', () => {
     it('Should be able to handle the callback hooks when performing actions;', () => {
 
         const mockModels = { first: {}, second: {}, third: {} };
-
-        component.hooks.didAdd    = () => {};
-        component.hooks.didDelete = () => {};
 
         spyOn(component.hooks, 'didAdd');
         spyOn(component.hooks, 'didDelete');


### PR DESCRIPTION
@Wildhoney 

This is similar to #91 where hooks cannot be defined on a component because they get overwritten. The ideal situation would be that like the options, we do not use a global object... unfortunately, in my testing, it was timing out... 

Thoughts?