### PR TITLE
Relax Ember and Handlebars bower constraints

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,8 @@
   ],
   "dependencies": {
     "jquery": ">=1.11.1 <=2.1.x",
-    "ember": "~1.6.1",
-    "handlebars": "~1.3.0"
+    "ember": ">= 1.6 <= 1.14",
+    "handlebars": ">=1.3.0 <=3.0.x"
   },
   "devDependencies": {
     "jasmine": "~2.0.1",


### PR DESCRIPTION
We require this to get up to date on Ember 1.13 before we can transition to 2.0.

Perhaps this could be released as v0.10.1?