### PR TITLE
Add support context sensitive events

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ Use as singular or in block form &mdash; `Droplet.Area` will create a `div` with
 {{x-droplet-area}}
 ```
 
+If you need have several droppable areas on the same page handling hooks independently, a context must be supplied:
+
+```html
+{{x-droplet-area ctx=this}}
+```
+
 ### Image Preview
 
 ```javascript
@@ -159,6 +165,12 @@ Use in its singular form &ndash; can use either `Droplet.MultipleInput` or `Drop
 
 ```html
 {{x-droplet-input}}
+```
+
+If you need have several input fields on the same page handling hooks independently, a context must be supplied:
+
+```html
+{{x-droplet-input ctx=this}}
 ```
 
 Example

--- a/components/Droplet.js
+++ b/components/Droplet.js
@@ -272,8 +272,10 @@
             $Ember.merge(options, this.get('options'));
             set(this, 'options', options);
 
-            this.DropletEventBus && this.DropletEventBus.subscribe(EVENT_NAME, this, (...files) => {
-                this.send('prepareFiles', ...files);
+            this.DropletEventBus && this.DropletEventBus.subscribe(EVENT_NAME, this, (ctx, ...files) => {
+                if (!ctx || ctx === this) {
+                    this.send('prepareFiles', ...files);
+                }
             });
 
             this._super();
@@ -744,7 +746,8 @@
          * @return {Model[]}
          */
         handleFiles(models) {
-            this.DropletEventBus && this.DropletEventBus.publish(EVENT_NAME, ...fromArray(models));
+            this.DropletEventBus && this.DropletEventBus.publish(
+                EVENT_NAME, this.get('ctx'), ...fromArray(models));
             return models;
         },
 
@@ -894,7 +897,8 @@
          * @return {void}
          */
         handleFiles(models) {
-            this.DropletEventBus && this.DropletEventBus.publish(EVENT_NAME, ...fromArray(models));
+            this.DropletEventBus && this.DropletEventBus.publish(
+                EVENT_NAME, this.get('ctx'), ...fromArray(models));
         }
         
     });


### PR DESCRIPTION
Add support for optionally passing a context with events on the event
bus. This makes it possible for `Area`, `SingleInput` and
`MultipleInput` components to address events to a particular instance
of a Droplet component.